### PR TITLE
Parallelize Schulze

### DIFF
--- a/schulze.go
+++ b/schulze.go
@@ -1,130 +1,168 @@
 package govote
 
 import (
-    "errors"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
 )
 
-// SchulzePoll is a Condorcet poll using the Schulze method 
+// SchulzePoll is a Condorcet poll using the Schulze method
 type SchulzePoll struct {
-    candidates     []string
-    ballots        [][]string
-    PP             map[CPair]int // pairwise preferences
-    SP             map[CPair]int // strongest path
+	candidates []string
+	ballots    [][]string
+	PP         map[CPair]int // pairwise preferences
+	SP         map[CPair]int // strongest path
 }
 
 // Evaluate poll; returns list of winners as slice of candidate names and
 // ranking as slice of CScores
 func (p *SchulzePoll) Evaluate() ([]string, []CScore, error) {
-    if p.candidates == nil || p.ballots == nil { 
-        return []string{}, []CScore{}, errors.New("no candidates or no ballots") 
-    }
-    winners, ranks := p.getWinners()
-    return winners, ranks, nil
+	if p.candidates == nil || p.ballots == nil {
+		return []string{}, []CScore{}, errors.New("no candidates or no ballots")
+	}
+	winners, ranks := p.getWinners()
+	return winners, ranks, nil
 }
 
 // AddBallot submits a ballot to the poll, returns true on success, false on failure
 func (p *SchulzePoll) AddBallot(ballot []string) (ok bool) {
-    removeDuplicates(&ballot)
-    for _, bv := range ballot {
-        ok = false; for _, cv := range p.candidates {
-            if cv == bv { ok = true; break }
-        }
-        if !ok { return } // false / bad candidate
-    }
-    if !ok { return } // false / empty ballot
-    p.ballots = append(p.ballots, ballot)
-    return // true
+	removeDuplicates(&ballot)
+	for _, bv := range ballot {
+		ok = false
+		for _, cv := range p.candidates {
+			if cv == bv {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return
+		} // false / bad candidate
+	}
+	if !ok {
+		return
+	} // false / empty ballot
+	p.ballots = append(p.ballots, ballot)
+	return // true
 }
 
 // Returns the rank of a candidate on a specific ballot or -1 if unranked
 func (p SchulzePoll) getBallotRank(idx, i int) int {
-    ballot := p.ballots[idx]
-    for k, v := range ballot {
-        if v == p.candidates[i] { return k }
-    }
-    return -1
+	ballot := p.ballots[idx]
+	for k, v := range ballot {
+		if v == p.candidates[i] {
+			return k
+		}
+	}
+	return -1
 }
 
 // Returns number of voters strictly prefering candidate i to j
-func (p SchulzePoll) comparePref(i, j int) (ct int) {
-    for k := range p.ballots {
-        ri, rj := p.getBallotRank(k, i), p.getBallotRank(k, j)
-        if ri == -1 || rj == -1 { continue } 
-        if ri < rj              { ct++ }
-    }
-    return
+func (p SchulzePoll) comparePref(i, j int) int {
+	var wg sync.WaitGroup
+	var ct int32
+
+	var divided [][][]string
+	chunkSize := (len(p.ballots) + runtime.GOMAXPROCS(0) - 1) / runtime.GOMAXPROCS(0)
+	for i := 0; i < len(p.ballots); i += chunkSize {
+		end := i + chunkSize
+		if end > len(p.ballots) {
+			end = len(p.ballots)
+		}
+		divided = append(divided, p.ballots[i:end])
+	}
+
+	wg.Add(len(divided))
+	for _, ballots := range divided {
+		go func(ballots [][]string) {
+			defer func() { wg.Done() }()
+			for k := range ballots {
+				ri, rj := p.getBallotRank(k, i), p.getBallotRank(k, j)
+				if ri == -1 || rj == -1 {
+					continue
+				}
+				if ri < rj {
+					atomic.AddInt32(&ct, 1)
+				}
+			}
+		}(ballots)
+	}
+
+	wg.Wait()
+	return int(ct)
 }
 
 func (p *SchulzePoll) getWinners() (winners []string, ranks []CScore) {
-    p.PP = make(map[CPair]int)                   // pairwise preferences
-    p.SP = make(map[CPair]int)                   // strongest paths
-    won := make([]bool, len(p.candidates))       // winners marked true by index
-    ct := len(p.candidates)                      // number of candidates
-    tally := make(map[string]int)                // scores keyed by candidate name
+	p.PP = make(map[CPair]int)             // pairwise preferences
+	p.SP = make(map[CPair]int)             // strongest paths
+	won := make([]bool, len(p.candidates)) // winners marked true by index
+	ct := len(p.candidates)                // number of candidates
+	tally := make(map[string]int)          // scores keyed by candidate name
 
-    // compute pairwise preferences
-    for i := 0; i < ct; i++ {
-        for j := 0; j < ct; j++ {
-            if i != j {
-                p.PP[CPair{i, j}] = p.comparePref(i, j)
-            }
-        }
-    }
+	// compute pairwise preferences
+	for i := 0; i < ct; i++ {
+		for j := 0; j < ct; j++ {
+			if i != j {
+				p.PP[CPair{i, j}] = p.comparePref(i, j)
+			}
+		}
+	}
 
-    // compute strongest paths
-    for i := 0; i < ct; i++ {
-        for j := 0; j < ct; j++ {
-            if i != j {
-                if p.PP[CPair{i, j}] > p.PP[CPair{j, i}] {
-                    p.SP[CPair{i, j}] = p.PP[CPair{i, j}]
-                } else {
-                    p.SP[CPair{i, j}] = 0
-                }
-            }
-        }
-    }
+	// compute strongest paths
+	for i := 0; i < ct; i++ {
+		for j := 0; j < ct; j++ {
+			if i != j {
+				if p.PP[CPair{i, j}] > p.PP[CPair{j, i}] {
+					p.SP[CPair{i, j}] = p.PP[CPair{i, j}]
+				} else {
+					p.SP[CPair{i, j}] = 0
+				}
+			}
+		}
+	}
 
-    for i := 0; i < ct; i++ {
-        for j := 0; j < ct; j++ {
-            if i != j {
-                for k := 0; k < ct; k++ {
-                    if i != k && j != k {
-                        var(
-                            SPjk = p.SP[CPair{j, k}]
-                            SPji = p.SP[CPair{j, i}]
-                            SPik = p.SP[CPair{i, k}]
-                        ) 
-                        p.SP[CPair{j, k}] = max(SPjk, min(SPji, SPik))
-                    }
-                }
-            }
-        }
-    }
+	for i := 0; i < ct; i++ {
+		for j := 0; j < ct; j++ {
+			if i != j {
+				for k := 0; k < ct; k++ {
+					if i != k && j != k {
+						var (
+							SPjk = p.SP[CPair{j, k}]
+							SPji = p.SP[CPair{j, i}]
+							SPik = p.SP[CPair{i, k}]
+						)
+						p.SP[CPair{j, k}] = max(SPjk, min(SPji, SPik))
+					}
+				}
+			}
+		}
+	}
 
-    // mark winners
-    for i := 0; i < ct; i++ {
-        won[i] = true
-    }
+	// mark winners
+	for i := 0; i < ct; i++ {
+		won[i] = true
+	}
 
-    for i := 0; i < ct; i++ {
-        for j := 0; j < ct; j++ {
-            if i != j {
-                if p.SP[CPair{j, i}] > p.SP[CPair{i, j}] {
-                    won[i] = false
-                    tally[p.candidates[i]] += 0   // creates entry for Condorcet loser
-                } else {
-                    tally[p.candidates[i]]++      // candidate preferred to x others
-                }
-            }
-        }
-    }
-    ranks = sortScoresDesc(tally)
+	for i := 0; i < ct; i++ {
+		for j := 0; j < ct; j++ {
+			if i != j {
+				if p.SP[CPair{j, i}] > p.SP[CPair{i, j}] {
+					won[i] = false
+					tally[p.candidates[i]] += 0 // creates entry for Condorcet loser
+				} else {
+					tally[p.candidates[i]]++ // candidate preferred to x others
+				}
+			}
+		}
+	}
+	ranks = sortScoresDesc(tally)
 
-    // make winners list
-    for i := 0; i < ct; i++ {
-        if won[i] == true { 
-            winners = append(winners, p.candidates[i])
-        }
-    }
-    return
+	// make winners list
+	for i := 0; i < ct; i++ {
+		if won[i] == true {
+			winners = append(winners, p.candidates[i])
+		}
+	}
+	return
 }

--- a/vote_test.go
+++ b/vote_test.go
@@ -1,0 +1,157 @@
+package govote
+
+import (
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func democrats() map[string]int {
+	return map[string]int{
+		"Biden":        29,
+		"Sanders":      20,
+		"Harris":       5,
+		"O'Rourke":     4,
+		"Warren":       4,
+		"Booker":       3,
+		"Delaney":      3,
+		"Klobuchar":    3,
+		"Castro":       1,
+		"Gabbard":      1,
+		"Gillibrand":   1,
+		"Hickenlooper": 1,
+		"Inslee":       1,
+		"Yang":         1,
+		"Buttigieg":    0,
+		"Williamson":   0,
+	}
+}
+
+func candidateList(weights map[string]int) []string {
+	out := make([]string, 0, len(weights))
+	for name := range weights {
+		out = append(out, name)
+	}
+	return out
+}
+
+func weighted(weights map[string]int) []*string {
+	i := 0
+	length := 100 + len(weights)
+	result := make([]*string, 0, length)
+	for name, v := range weights {
+	REDO:
+		n := name // BUG: loop capture?
+		result = append(result, &n)
+		i++
+		v--
+		if v >= 0 {
+			goto REDO
+		}
+	}
+	return result
+}
+
+func randomBallot(random *rand.Rand, choices []*string, min, max int) []string {
+	if min > max {
+		panic("min > max")
+	}
+	if min < 1 {
+		panic("min < 1")
+	}
+	if max > len(choices) {
+		panic("max > len(choices)")
+	}
+
+	count := random.Intn(max-min+1) + min
+	votes := make(map[string]bool, count)
+	output := make([]string, count, count)
+	for i := 0; i < count; i++ {
+	RETRY: // suboptimal but better than building a giant decision tree in memory since we don't expect more than a handful of votes per
+		index := random.Intn(len(choices))
+		vote := *choices[index]
+		if exists := votes[vote]; exists {
+			goto RETRY
+		}
+		votes[vote] = true
+		output[i] = vote
+	}
+	return output
+}
+
+// always store the result to a package level variable
+// so the compiler cannot eliminate the Benchmark itself.
+var resultSchulze []string
+
+func BenchmarkSchulze1Procs(b *testing.B) {
+	benchmarkSchulze(1, b)
+}
+
+func BenchmarkSchulze2Procs(b *testing.B) {
+	benchmarkSchulze(2, b)
+}
+
+func BenchmarkSchulzeGOMAXPROCS(b *testing.B) {
+	benchmarkSchulze(runtime.GOMAXPROCS(0), b)
+}
+
+func BenchmarkSchulze2xGOMAXPROCS(b *testing.B) {
+	benchmarkSchulze(2*runtime.GOMAXPROCS(0), b)
+}
+
+var benchmarkSchulzeSetupOnce sync.Once
+var benchmarkSchulzePoll SchulzePoll
+
+func benchmarkSchulzeSetup() {
+	const population = 10000
+
+	random := rand.New(rand.NewSource(2019))
+
+	dems := democrats()
+	candidates := candidateList(dems)
+	deck := weighted(dems)
+	poll, _ := Schulze.New(candidates)
+
+	length := runtime.GOMAXPROCS(0)
+	c := make(chan []string, length)
+	quitters := make([]chan bool, length)
+	for i := 0; i < length; i++ {
+		quitters[i] = make(chan bool)
+		s := rand.NewSource(random.Int63())
+		random := rand.New(s)
+		go func(quit chan bool) {
+		RETRY:
+			ballot := randomBallot(random, deck, 1, len(candidates))
+			select {
+			case <-quit:
+			case c <- ballot:
+				goto RETRY
+			}
+		}(quitters[i])
+	}
+	for i := 0; i < population; i++ {
+		ballot := <-c
+		poll.AddBallot(ballot)
+	}
+	for i := 0; i < length; i++ {
+		quitters[i] <- true
+	}
+	close(c)
+	benchmarkSchulzePoll = poll
+}
+
+func benchmarkSchulze(numProcs int, b *testing.B) {
+	benchmarkSchulzeSetupOnce.Do(benchmarkSchulzeSetup)
+
+	oldnumProcs := runtime.GOMAXPROCS(numProcs)
+	defer runtime.GOMAXPROCS(oldnumProcs)
+	// run the benchmark
+	for n := 0; n < b.N; n++ {
+		result, _, err := benchmarkSchulzePoll.Evaluate()
+		resultSchulze = result
+		if err != err {
+			b.Fatalf("Evaluate returned error %v", err)
+		}
+	}
+}


### PR DESCRIPTION
* adds benchmarks with synthetic data for Schulze.
* Schulze uses `GOMAXPROCS` to process chunks of ballots inside `comparePref()`. Speed of original implementation is about equal to running with `GOMAXPROCS=1`, so the benchmark output should accurately reflect speed-up (3-4x on a Ryzen 7 2700X)
```
Benchmark_min-16                        2000000000               0.25 ns/op
Benchmark_max-16                        2000000000               0.25 ns/op
Benchmark_sortScoresAsc-16               2000000               723 ns/op
Benchmark_sortScoresDesc-16              2000000               813 ns/op
Benchmark_randIntn-16                     100000             12236 ns/op
Benchmark_removeDuplicates-16            5000000               242 ns/op
BenchmarkSchulze1Procs-16                     10         136853720 ns/op
BenchmarkSchulze2Procs-16                     20         101309683 ns/op
BenchmarkSchulzeGOMAXPROCS-16                 30          39483270 ns/op
BenchmarkSchulze2xGOMAXPROCS-16               20          56550569 ns/op
```